### PR TITLE
feat: add client canary check and demo stubs

### DIFF
--- a/apps/web/app/_check/page.tsx
+++ b/apps/web/app/_check/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function CanaryPage() {
+  const [timestamp, setTimestamp] = useState('');
+
+  useEffect(() => {
+    setTimestamp(new Date().toISOString());
+  }, []);
+
+  return (
+    <div className="container-page space-y-4">
+      <h1 className="text-xl font-semibold">Canary OK</h1>
+      <p className="text-sm">{timestamp}</p>
+      <span className="inline-block rounded bg-green-600 px-2 py-1 text-xs font-medium">
+        Demo Mode: ON
+      </span>
+    </div>
+  );
+}

--- a/apps/web/app/api/generate-ideas/route.ts
+++ b/apps/web/app/api/generate-ideas/route.ts
@@ -1,58 +1,5 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
-const DEFAULT_CHANNEL_ID = '1'; // Usaremos um ID fixo para o canal padrão
 
 export async function POST() {
-  try {
-    // LANCE 1: VERIFICAR E CRIAR O CANAL (A TORRE)
-    // O 'upsert' é um comando inteligente: ele tenta encontrar um canal com o id '1'.
-    // Se encontrar, não faz nada. Se não encontrar, ele cria um.
-    await prisma.channel.upsert({
-      where: { id: DEFAULT_CHANNEL_ID },
-      update: {}, // Não queremos atualizar nada se ele já existir
-      create: {
-        id: DEFAULT_CHANNEL_ID,
-        name: 'Faultline Economics Main',
-        locale: 'en',
-      },
-    });
-
-    // LANCE 2: CRIAR A IDEIA-MÃE (O PEÃO)
-    const parentIdea = await prisma.idea.create({
-      data: {
-        channelId: DEFAULT_CHANNEL_ID, // Agora garantimos que este ID existe
-        topic: 'Novas Ideias de Geopolítica Geradas por IA',
-        status: 'Ideia',
-      },
-    });
-
-    // LANCE 3: CRIAR OS CANDIDATOS A TÍTULO (OS OUTROS PEÕES)
-    const generatedTitles = [
-      { title: 'A Geopolítica dos Cabos Submarinos' },
-      { title: 'Por que a Demografia da China é uma Bomba-Relógio' },
-      { title: 'O Estreito de Malaca: O Ponto Mais Importante do Mundo' },
-      { title: 'A Batalha pelos Semicondutores: EUA vs China' },
-      { title: 'Rússia: Uma Potência em Declínio Irreversível?' },
-    ];
-
-    const titlesToCreate = generatedTitles.map(t => ({
-      ...t,
-      ideaId: parentIdea.id,
-    }));
-
-    await prisma.titleCandidate.createMany({
-      data: titlesToCreate,
-    });
-
-    return NextResponse.json({ success: true, message: 'Canal verificado, 1 ideia e 5 títulos gerados!' });
-
-  } catch (error) {
-    console.error("Erro no fluxo de geração:", error);
-    return new NextResponse(
-      JSON.stringify({ success: false, error: 'Falha no fluxo de geração.' }),
-      { status: 500, headers: { 'Content-Type': 'application/json' } }
-    );
-  }
+  return NextResponse.json({ success: true });
 }

--- a/apps/web/app/api/ideas/route.ts
+++ b/apps/web/app/api/ideas/route.ts
@@ -1,22 +1,5 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
 
-const prisma = new PrismaClient();
-
-// Esta API agora busca os TÍTULOS, não as ideias.
 export async function GET() {
-  try {
-    const titles = await prisma.titleCandidate.findMany({
-      orderBy: {
-        createdAt: 'desc', // Ordena para mostrar os mais recentes primeiro
-      },
-    });
-    return NextResponse.json(titles);
-  } catch (error) {
-    console.error("Erro ao buscar títulos:", error);
-    return new NextResponse(
-      JSON.stringify({ error: 'Falha ao buscar os títulos.' }),
-      { status: 500, headers: { 'Content-Type': 'application/json' } }
-    );
-  }
+  return NextResponse.json([]);
 }

--- a/apps/web/app/dashboard/ideas/page.tsx
+++ b/apps/web/app/dashboard/ideas/page.tsx
@@ -1,8 +1,12 @@
-import { prisma } from '../../../lib/prisma'
-async function createIdea(formData: FormData){ 'use server'; const topic=String(formData.get('topic')||'').trim(); if(!topic) return; await prisma.idea.create({ data:{ topic, channelId:'seed-channel-1', score:3 } }) }
-export default async function Ideas(){ const ideas=await prisma.idea.findMany({ orderBy:{createdAt:'desc'}, take:50 })
-  return(<section className='card grid gap-3'>
-    <h2 className='text-[color:#d4af37] text-xl font-bold'>Ideas Hub</h2>
-    <form action={createIdea} className='flex gap-2'><input name='topic' className='input' placeholder='Add a new idea topic...' /><button className='btn'>Add</button></form>
-    <ul className='divide-y divide-neutral-800'>{ideas.map(i=>(<li key={i.id} className='py-3'><div className='font-semibold'>{i.topic}</div><div className='text-xs opacity-70'>score: {i.score ?? '-'} • {new Date(i.createdAt).toLocaleString()}</div></li>))}</ul>
-  </section>) }
+'use client';
+
+export default function Ideas() {
+  return (
+    <section className="card grid gap-3">
+      <h2 className="text-[color:#d4af37] text-xl font-bold">Ideas Hub</h2>
+      <p className="text-sm text-[color:var(--muted)]">
+        Demo Mode: no data available.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -1,4 +1,4 @@
-import Shell from '@/components/Shell';
+import { Shell } from '@/components/shell';
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   return <Shell>{children}</Shell>;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -23,6 +23,13 @@ export default function RootLayout({
           GeistMono.variable
         )}
       >
+        <header className="bg-[var(--panel)]">
+          <nav className="max-w-6xl mx-auto flex items-center justify-end gap-4 px-6 py-4">
+            <a href="/_check" className="text-sm hover:underline">
+              Check
+            </a>
+          </nav>
+        </header>
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- add client-only `_check` route with timestamp and demo badge
- link header to check page
- stub demo API routes and ideas page to avoid backend calls

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aed21860388333b94b3455c8bcda62