### PR TITLE
feat: redirect root to ideas dashboard

### DIFF
--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -1,4 +1,4 @@
-import Shell from '@/components/Shell';
+import { Shell } from '@/components/shell';
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   return <Shell>{children}</Shell>;

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,1 +1,12 @@
-export default { experimental: { serverActions: { bodySizeLimit: '10mb' } } };
+export default {
+  experimental: { serverActions: { bodySizeLimit: '10mb' } },
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: '/dashboard/ideas',
+        statusCode: 301,
+      },
+    ];
+  },
+};


### PR DESCRIPTION
## Summary
- redirect `/` to `/dashboard/ideas`
- fix case-sensitive shell import

## Testing
- `npm ci`
- `npm run build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68aed26983748333955282b5eac38c30